### PR TITLE
Hotfix/missing publisher advertise

### DIFF
--- a/ixblue_ins_driver/src/ros_publisher.cpp
+++ b/ixblue_ins_driver/src/ros_publisher.cpp
@@ -54,6 +54,9 @@ ROSPublisher::ROSPublisher() : nh("~"), diagPub(nh)
     stdTimeReferencePublisher =
         nh.advertise<sensor_msgs::TimeReference>("standard/timereference", 1);
     stdInsPublisher = nh.advertise<ixblue_ins_msgs::Ins>("ix/ins", 1);
+
+    // External Sensors
+    stdSVSPublisher = nh.advertise<ixblue_ins_msgs::SVS>("ix/svs", 1);
 }
 
 void ROSPublisher::onNewStdBinData(

--- a/ixblue_ins_driver/test/test_ixblue_ins_driver.cpp
+++ b/ixblue_ins_driver/test/test_ixblue_ins_driver.cpp
@@ -74,6 +74,20 @@ TEST(ROSPublisherTester, CanFillANavSatFixMsgWithWestLong)
               sensor_msgs::NavSatFix::COVARIANCE_TYPE_UNKNOWN);
 }
 
+TEST(ROSPublisherTester, CanFillSVSMsg) {
+  ixblue_stdbin_decoder::Data::SoundVelocity svs;
+  svs.ext_speedofsound_ms = 1492.01;
+  svs.validityTime_100us = 9999;
+
+  ixblue_stdbin_decoder::Data::BinaryNav nav;
+  nav.soundVelocity = svs;
+
+  const ixblue_ins_msgs::SVSPtr msg = ROSPublisher::toSVSMsg(nav);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_FLOAT_EQ(msg->sound_velocity, 1492.01);
+  EXPECT_EQ(msg->validity_time, 9999);
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### Features Description
- Add missing advertise: ```stdSVSPublisher = nh.advertise<ixblue_ins_msgs::SVS>("ix/svs", 1);```  I accidentally removed it when I undid the last commit about format.
- Add test case for the new SVS message

### Notes
 - New feature tested using the INS Rovins Nano and Valeport miniSVS.